### PR TITLE
feat(dialogue): add Level 4 dialogue resources

### DIFF
--- a/Resources/LevelFourEndDialogue.tres
+++ b/Resources/LevelFourEndDialogue.tres
@@ -1,0 +1,34 @@
+[gd_resource type="Resource" script_class="DialogueResource" load_steps=4 format=3 uid="uid://cm5h6n8kak0l2"]
+
+[ext_resource type="Script" uid="uid://1jg5kmdowv5h" path="res://Resources/DialogueResource.gd" id="1_end01"]
+[ext_resource type="Texture2D" uid="uid://c7hueeu5cboy5" path="res://Assets/Bust Shot/Main Character_Bust Shot_1_Normal.png" id="2_end02"]
+[ext_resource type="Texture2D" uid="uid://c7hueeu5cboy5" path="res://Assets/Bust Shot/Main Character_Bust Shot_1_Normal.png" id="3_end03"]
+
+[resource]
+script = ExtResource("1_end01")
+dialogue_sequence = Array[Dictionary]([{
+"character": "外星人",
+"line": "呼，呼，呼",
+"texture": Object()
+}, {
+"character": "科迪",
+"line": "...（小喘，凝重看着喘着粗气的对手）",
+"texture": ExtResource("2_end02")
+}, {
+"character": "外星人",
+"line": "可恶，居然被你打败了，那我就没理由拦你了",
+"texture": Object()
+}, {
+"character": "科迪",
+"line": "你剩下的同伴都在哪？",
+"texture": ExtResource("2_end02")
+}, {
+"character": "外星人",
+"line": "我的同伴已经去到世界各地了，想要打败我们可没这么容易，呵呵呵",
+"texture": Object()
+}, {
+"character": "科迪",
+"line": "可恶，我得加快脚步了",
+"texture": ExtResource("2_end02")
+}])
+metadata/_custom_type_script = "uid://1jg5kmdowv5h"

--- a/Resources/LevelFourIntroDialogue.tres
+++ b/Resources/LevelFourIntroDialogue.tres
@@ -1,0 +1,31 @@
+[gd_resource type="Resource" script_class="DialogueResource" load_steps=5 format=3 uid="uid://bm4g5n7h8qaq1"]
+
+[ext_resource type="Script" uid="uid://1jg5kmdowv5h" path="res://Resources/DialogueResource.gd" id="1_abc01"]
+[ext_resource type="Texture2D" uid="uid://c7hueeu5cboy5" path="res://Assets/Bust Shot/Main Character_Bust Shot_1_Normal.png" id="2_def02"]
+[ext_resource type="Texture2D" uid="uid://c7hueeu5cboy5" path="res://Assets/Bust Shot/Main Character_Bust Shot_1_Normal.png" id="3_ghi03"]
+[ext_resource type="Texture2D" uid="uid://c7hueeu5cboy5" path="res://Assets/Bust Shot/Main Character_Bust Shot_1_Normal.png" id="4_jkl04"]
+
+[resource]
+script = ExtResource("1_abc01")
+dialogue_sequence = Array[Dictionary]([{
+"character": "科迪",
+"line": "（想法：呃...这些都是...人骨！！）",
+"texture": ExtResource("2_def02")
+}, {
+"character": "科迪",
+"line": "你是谁！",
+"texture": ExtResource("3_ghi03")
+}, {
+"character": "外星人",
+"line": "刚刚我的队友跟我说你打败了他，看来你小子挺厉害",
+"texture": Object()
+}, {
+"character": "科迪",
+"line": "哼，没想到这么快又遇到一个",
+"texture": ExtResource("2_def02")
+}, {
+"character": "外星人",
+"line": "什么都不用说了，来PK吧！",
+"texture": Object()
+}])
+metadata/_custom_type_script = "uid://1jg5kmdowv5h"


### PR DESCRIPTION
## Summary
- Add LevelFourIntroDialogue.tres with 5 dialogue entries for catacombs intro scene
- Add LevelFourEndDialogue.tres with 6 dialogue entries for boss defeat sequence
- Configure alien character dialogues with empty Object() textures while maintaining texture field structure

## Test plan
- [ ] Verify dialogue resources load correctly in Godot editor
- [ ] Test dialogue system with new Level 4 intro and ending sequences
- [ ] Confirm alien characters display properly without textures
- [ ] Validate dialogue content matches Todo.txt specifications

Resolves #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)