### PR TITLE
feat(cutscenes): add dynamic backgrounds and animations to level 3

### DIFF
--- a/Resources/LevelThreeEndDialogue.tres
+++ b/Resources/LevelThreeEndDialogue.tres
@@ -1,17 +1,21 @@
-[gd_resource type="Resource" script_class="DialogueResource" load_steps=6 format=3 uid="uid://cxlfp3gdn3ov6"]
+[gd_resource type="Resource" script_class="DialogueResource" load_steps=10 format=3 uid="uid://cxlfp3gdn3ov6"]
 
 [ext_resource type="Script" uid="uid://1jg5kmdowv5h" path="res://Resources/DialogueResource.gd" id="1_7c084"]
+[ext_resource type="Texture2D" uid="uid://cqvk4g2tnklhg" path="res://Assets/Bust Shot/Boss_03-1_Bathhouse_Bust Shot_4_Exhausted.png" id="1_r7ag7"]
 [ext_resource type="Texture2D" uid="uid://cso6ed1wvmpen" path="res://Assets/Bust Shot/Main Character_Bust Shot_5_Pissed off.png" id="1_wrtoh"]
 [ext_resource type="Texture2D" uid="uid://k4ki7rksxqk4" path="res://Assets/Bust Shot/Main Character_Bust Shot_4_Nervous.png" id="2_krglk"]
 [ext_resource type="Texture2D" uid="uid://c7hueeu5cboy5" path="res://Assets/Bust Shot/Main Character_Bust Shot_1_Normal.png" id="3_0ovxv"]
+[ext_resource type="Texture2D" uid="uid://g1bfft2obf72" path="res://Assets/Bust Shot/Boss_03-1_Bathhouse_Bust Shot_5_Boasting.png" id="3_2ogr1"]
 [ext_resource type="Texture2D" uid="uid://b4txomu62ybeo" path="res://Assets/Bust Shot/Main Character_Bust Shot_2_Hehe.png" id="4_ebffo"]
+[ext_resource type="Texture2D" uid="uid://cv7uuvspcvy25" path="res://Assets/Bust Shot/Boss_03-2_Bathhouse_Bust Shot_2_Relieved.png" id="5_icecp"]
+[ext_resource type="Texture2D" uid="uid://dare3w2bd12ef" path="res://Assets/Bust Shot/Boss_03-2_Bathhouse_Bust Shot_3_Concerned.png" id="7_1omek"]
 
 [resource]
 script = ExtResource("1_7c084")
 dialogue_sequence = Array[Dictionary]([{
 "character": "敌人",
 "line": "哼，小子挺厉害啊",
-"texture": null
+"texture": ExtResource("1_r7ag7")
 }, {
 "character": "科迪",
 "line": "你要说话算话",
@@ -19,7 +23,7 @@ dialogue_sequence = Array[Dictionary]([{
 }, {
 "character": "敌人",
 "line": "哼哼哼，我们可是最受信用的种族，既然输了，那我也会遵守诺言，可是小子，你得小心了，比我厉害的还有8个呢，呵呵呵",
-"texture": null
+"texture": ExtResource("3_2ogr1")
 }, {
 "character": "科迪",
 "line": "。。。谢老板你没事吧",
@@ -27,7 +31,7 @@ dialogue_sequence = Array[Dictionary]([{
 }, {
 "character": "谢老板",
 "line": "真是谢谢你啊，要不是你我的小命难保啊",
-"texture": null
+"texture": ExtResource("5_icecp")
 }, {
 "character": "科迪",
 "line": "谢老板，你要多加小心啊，我先走一步了",
@@ -35,7 +39,7 @@ dialogue_sequence = Array[Dictionary]([{
 }, {
 "character": "谢老板",
 "line": "科迪，你准备去哪里？",
-"texture": null
+"texture": ExtResource("7_1omek")
 }, {
 "character": "科迪",
 "line": "从他们那里得知了他们前来入侵地球的原因，如果不快点想办法找出他们剩下的同伴并一一击败的话后果会不堪设想，我要去追上刚刚那个家伙，这样一定能与他的同伴碰面",
@@ -43,7 +47,7 @@ dialogue_sequence = Array[Dictionary]([{
 }, {
 "character": "谢老板",
 "line": "虽然让你一个人前去很危险，但是我也帮不上什么忙，我能做的只有完全相信你，你一定要注意安全，平安回来啊",
-"texture": null
+"texture": ExtResource("7_1omek")
 }, {
 "character": "科迪",
 "line": "你放心吧谢老板！",

--- a/Resources/LevelThreeIntroDialogue.tres
+++ b/Resources/LevelThreeIntroDialogue.tres
@@ -1,9 +1,12 @@
-[gd_resource type="Resource" script_class="DialogueResource" load_steps=5 format=3 uid="uid://ctiq7lsqn0ksc"]
+[gd_resource type="Resource" script_class="DialogueResource" load_steps=8 format=3 uid="uid://ctiq7lsqn0ksc"]
 
 [ext_resource type="Script" uid="uid://1jg5kmdowv5h" path="res://Resources/DialogueResource.gd" id="1_5iwia"]
 [ext_resource type="Texture2D" uid="uid://cftsv4fkl57nm" path="res://Assets/Bust Shot/Main Character_Bust Shot_3_Shocked.png" id="1_7il0l"]
 [ext_resource type="Texture2D" uid="uid://cso6ed1wvmpen" path="res://Assets/Bust Shot/Main Character_Bust Shot_5_Pissed off.png" id="2_tg7nb"]
 [ext_resource type="Texture2D" uid="uid://k4ki7rksxqk4" path="res://Assets/Bust Shot/Main Character_Bust Shot_4_Nervous.png" id="3_fadi1"]
+[ext_resource type="Texture2D" uid="uid://bl3skjeud3o35" path="res://Assets/Bust Shot/Boss_03-2_Bathhouse_Bust Shot_1_Kidnap.png" id="4_5kxdx"]
+[ext_resource type="Texture2D" uid="uid://cfnosdsamcwv6" path="res://Assets/Bust Shot/Boss_03-1_Bathhouse_Bust Shot_1_Normal.png" id="5_4dj72"]
+[ext_resource type="Texture2D" uid="uid://be3itfwuroox1" path="res://Assets/Bust Shot/Boss_03-1_Bathhouse_Bust Shot_2_Aggressive.png" id="6_7jsc5"]
 
 [resource]
 script = ExtResource("1_5iwia")
@@ -26,11 +29,11 @@ dialogue_sequence = Array[Dictionary]([{
 }, {
 "character": "谢老板",
 "line": "唔。。。唔唔",
-"texture": null
+"texture": ExtResource("4_5kxdx")
 }, {
 "character": "敌人",
 "line": "噢？哪来的不要命的？！",
-"texture": null
+"texture": ExtResource("5_4dj72")
 }, {
 "character": "科迪",
 "line": "你们的目的不就是想找人投篮吗？我跟你比，如果我赢了你就放了谢老板！",
@@ -38,7 +41,7 @@ dialogue_sequence = Array[Dictionary]([{
 }, {
 "character": "敌人",
 "line": "哟呵！居然知道规矩，看来你已经打败过我们的人了，不错嘛，那我可要看看你的能力了，只要你能赢，我就直接离开。",
-"texture": null
+"texture": ExtResource("6_7jsc5")
 }, {
 "character": "科迪",
 "line": "（这家伙好像更厉害点，我不能掉以轻心啊）",

--- a/Scenes/CutScenes/LevelThree/LevelThreeEnd.gd
+++ b/Scenes/CutScenes/LevelThree/LevelThreeEnd.gd
@@ -1,0 +1,25 @@
+extends "res://Scenes/CutScenes/Cutscene.gd"
+
+@onready var background: Sprite2D = $Background
+@onready var animation_player: AnimationPlayer = $AnimationPlayer
+
+var dialogue_paused: bool = false
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	super._ready()
+	SignalManager.on_dialogue_updated.connect(_check_for_animation)
+	animation_player.animation_finished.connect(_on_animation_finished)
+
+
+func _check_for_animation(_dialogue_data: Dictionary) -> void:
+	if !dialogue_paused && DialogueManager.current_line_index == 3:
+		canvas_layer.hide()
+		dialogue_paused = true
+		animation_player.play('background_animation')
+
+
+func _on_animation_finished(animation_name: String) -> void:
+	if animation_name == "background_animation":
+		canvas_layer.show()
+		DialogueManager.proceed_dialogue()

--- a/Scenes/CutScenes/LevelThree/LevelThreeEnd.gd.uid
+++ b/Scenes/CutScenes/LevelThree/LevelThreeEnd.gd.uid
@@ -1,0 +1,1 @@
+uid://b8aecn7bl37ql

--- a/Scenes/CutScenes/LevelThree/LevelThreeEnd.tscn
+++ b/Scenes/CutScenes/LevelThree/LevelThreeEnd.tscn
@@ -1,9 +1,13 @@
-[gd_scene load_steps=7 format=3 uid="uid://c1a6aiphagi8b"]
+[gd_scene load_steps=13 format=3 uid="uid://c1a6aiphagi8b"]
 
-[ext_resource type="Script" uid="uid://yf75k6e5tbmd" path="res://Scenes/CutScenes/Cutscene.gd" id="1_1iq6g"]
+[ext_resource type="Script" uid="uid://b8aecn7bl37ql" path="res://Scenes/CutScenes/LevelThree/LevelThreeEnd.gd" id="1_fngv2"]
 [ext_resource type="PackedScene" uid="uid://bh7k5nevgoxhj" path="res://Scenes/UI/Dialog/Dialog.tscn" id="2_fngv2"]
 [ext_resource type="Resource" uid="uid://cxlfp3gdn3ov6" path="res://Resources/LevelThreeEndDialogue.tres" id="2_p2t6u"]
+[ext_resource type="Texture2D" uid="uid://ccnf2vpl7jefe" path="res://Assets/Background/Background_03_Bathhouse-3_Hole-1.png" id="3_253f0"]
+[ext_resource type="Texture2D" uid="uid://iu10wdjktmi4" path="res://Assets/Background/Background_03_Bathhouse-2_Inside.png" id="3_c4nrw"]
+[ext_resource type="Texture2D" uid="uid://caoegfdirnp7f" path="res://Assets/Background/Background_03_Bathhouse-3_Hole-2.png" id="4_c4nrw"]
 [ext_resource type="PackedScene" uid="uid://dabrcvdqw3sq8" path="res://Scenes/UI/MainMenu/MainMenu.tscn" id="4_iaoxh"]
+[ext_resource type="Texture2D" uid="uid://dal6j2h45siap" path="res://Assets/Background/Background_03_Bathhouse-3_Hole-3.png" id="5_0cedr"]
 
 [sub_resource type="Animation" id="Animation_p2t6u"]
 resource_name = "level_three_end"
@@ -22,14 +26,51 @@ tracks/0/keys = {
 }]
 }
 
+[sub_resource type="Animation" id="Animation_87amc"]
+resource_name = "background_animation"
+step = 0.1
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Background:texture")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.2, 0.5, 0.8),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 0,
+"values": [ExtResource("3_c4nrw"), ExtResource("3_253f0"), ExtResource("4_c4nrw"), ExtResource("5_0cedr")]
+}
+
+[sub_resource type="Animation" id="Animation_poop6"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Background:texture")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [ExtResource("3_c4nrw")]
+}
+
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_iaoxh"]
 _data = {
+&"RESET": SubResource("Animation_poop6"),
+&"background_animation": SubResource("Animation_87amc"),
 &"level_three_end": SubResource("Animation_p2t6u")
 }
 
 [node name="LevelThreeEnd" type="Node2D"]
-script = ExtResource("1_1iq6g")
+script = ExtResource("1_fngv2")
 dialogue_data = ExtResource("2_p2t6u")
+
+[node name="Background" type="Sprite2D" parent="."]
+position = Vector2(145, 75)
+texture = ExtResource("3_c4nrw")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {

--- a/Scenes/CutScenes/LevelThree/LevelThreeIntro.gd
+++ b/Scenes/CutScenes/LevelThree/LevelThreeIntro.gd
@@ -1,0 +1,16 @@
+extends "res://Scenes/CutScenes/Cutscene.gd"
+
+@onready var background: Sprite2D = $Background
+
+var switch_background: bool = false
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	super._ready()
+	SignalManager.on_dialogue_updated.connect(_on_dialogue_updated)
+
+
+func _on_dialogue_updated(_dialogue_data: Dictionary) -> void:
+	if !switch_background && DialogueManager.current_line_index == 3:
+		background.texture = preload("uid://iu10wdjktmi4")
+		switch_background = true

--- a/Scenes/CutScenes/LevelThree/LevelThreeIntro.gd.uid
+++ b/Scenes/CutScenes/LevelThree/LevelThreeIntro.gd.uid
@@ -1,0 +1,1 @@
+uid://dx4cxr5wpm5od

--- a/Scenes/CutScenes/LevelThree/LevelThreeIntro.tscn
+++ b/Scenes/CutScenes/LevelThree/LevelThreeIntro.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=7 format=3 uid="uid://ct1uiw41hc1ff"]
+[gd_scene load_steps=8 format=3 uid="uid://ct1uiw41hc1ff"]
 
-[ext_resource type="Script" uid="uid://yf75k6e5tbmd" path="res://Scenes/CutScenes/Cutscene.gd" id="1_scwmd"]
+[ext_resource type="Script" uid="uid://dx4cxr5wpm5od" path="res://Scenes/CutScenes/LevelThree/LevelThreeIntro.gd" id="1_scwmd"]
 [ext_resource type="Resource" uid="uid://ctiq7lsqn0ksc" path="res://Resources/LevelThreeIntroDialogue.tres" id="2_nk1u6"]
 [ext_resource type="PackedScene" uid="uid://bh7k5nevgoxhj" path="res://Scenes/UI/Dialog/Dialog.tscn" id="3_j6lc1"]
+[ext_resource type="Texture2D" uid="uid://dm5w58ise7m5o" path="res://Assets/Background/Background_03_Bathhouse-1_Outside.png" id="3_nk1u6"]
 [ext_resource type="PackedScene" uid="uid://boppue0wwcj05" path="res://Scenes/Levels/LevelThree/LevelThree.tscn" id="4_dhmuu"]
 
 [sub_resource type="Animation" id="Animation_vv244"]
@@ -30,6 +31,10 @@ _data = {
 [node name="LevelThreeIntro" type="Node2D"]
 script = ExtResource("1_scwmd")
 dialogue_data = ExtResource("2_nk1u6")
+
+[node name="Background" type="Sprite2D" parent="."]
+position = Vector2(145, 75)
+texture = ExtResource("3_nk1u6")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {

--- a/Scenes/Levels/LevelThree/LevelThree.tscn
+++ b/Scenes/Levels/LevelThree/LevelThree.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://boppue0wwcj05"]
+[gd_scene load_steps=5 format=3 uid="uid://boppue0wwcj05"]
 
 [ext_resource type="PackedScene" uid="uid://cnc8vwtc5d7d7" path="res://Scenes/Levels/LevelBase/LevelBase.tscn" id="1_dqxtk"]
 [ext_resource type="PackedScene" uid="uid://cs7kkatnq4wci" path="res://Scenes/Hoop/Hoop.tscn" id="2_6chg6"]
 [ext_resource type="PackedScene" uid="uid://c1a6aiphagi8b" path="res://Scenes/CutScenes/LevelThree/LevelThreeEnd.tscn" id="2_7upe8"]
+[ext_resource type="Texture2D" uid="uid://iu10wdjktmi4" path="res://Assets/Background/Background_03_Bathhouse-2_Inside.png" id="4_pfd2j"]
 
 [node name="LevelThree" instance=ExtResource("1_dqxtk")]
 next_level_scene = ExtResource("2_7upe8")
@@ -11,3 +12,7 @@ current_level_number = 3
 
 [node name="Hoop" parent="." index="1" instance=ExtResource("2_6chg6")]
 position = Vector2(175, 50)
+
+[node name="Background" type="Sprite2D" parent="." index="3"]
+position = Vector2(145, 75)
+texture = ExtResource("4_pfd2j")


### PR DESCRIPTION
## Summary
- Add custom scripts for LevelThreeIntro and LevelThreeEnd cutscenes extending base Cutscene class
- Implement background switching in LevelThreeIntro at dialogue index 3 (switches to inside bathhouse)
- Add 3-frame hole animation sequence in LevelThreeEnd with dialogue pause/resume
- Hide dialogue UI during background animation playback for better visual experience
- Add background sprites to all level 3 scenes
- Update dialogue resources with character bust shot textures

## Test plan
- [ ] Verify LevelThreeIntro background switches correctly at the appropriate dialogue line
- [ ] Confirm LevelThreeEnd hole animation plays smoothly and dialogue resumes after
- [ ] Test that dialogue UI hides/shows correctly during animation
- [ ] Verify all character bust shots display properly in dialogue

🤖 Generated with [Claude Code](https://claude.com/claude-code)